### PR TITLE
Edit mode support

### DIFF
--- a/commons/src/main/java/architect/commons/view/PresentedFrameLayout.java
+++ b/commons/src/main/java/architect/commons/view/PresentedFrameLayout.java
@@ -40,12 +40,17 @@ public abstract class PresentedFrameLayout<T extends ViewPresenter> extends Fram
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        presenter.takeView(this);
+        if (!isInEditMode()) {
+            presenter.takeView(this);
+        }
+
     }
 
     @Override
     protected void onDetachedFromWindow() {
-        presenter.dropView(this);
+        if (!isInEditMode()) {
+            presenter.dropView(this);
+        }
         super.onDetachedFromWindow();
     }
 

--- a/commons/src/main/java/architect/commons/view/PresentedLinearLayout.java
+++ b/commons/src/main/java/architect/commons/view/PresentedLinearLayout.java
@@ -40,12 +40,16 @@ public abstract class PresentedLinearLayout<T extends ViewPresenter> extends Lin
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        presenter.takeView(this);
+        if (!isInEditMode()) {
+            presenter.takeView(this);
+        }
     }
 
     @Override
     protected void onDetachedFromWindow() {
-        presenter.dropView(this);
+        if (!isInEditMode()) {
+            presenter.dropView(this);
+        }
         super.onDetachedFromWindow();
     }
 

--- a/commons/src/main/java/architect/commons/view/PresentedRelativeLayout.java
+++ b/commons/src/main/java/architect/commons/view/PresentedRelativeLayout.java
@@ -39,12 +39,16 @@ public abstract class PresentedRelativeLayout<T extends ViewPresenter> extends R
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        presenter.takeView(this);
+        if (!isInEditMode()) {
+            presenter.takeView(this);
+        }
     }
 
     @Override
     protected void onDetachedFromWindow() {
-        presenter.dropView(this);
+        if (!isInEditMode()) {
+            presenter.dropView(this);
+        }
         super.onDetachedFromWindow();
     }
 

--- a/commons/src/main/java/architect/commons/view/PresentedScrollView.java
+++ b/commons/src/main/java/architect/commons/view/PresentedScrollView.java
@@ -39,12 +39,16 @@ public abstract class PresentedScrollView<T extends ViewPresenter> extends Scrol
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        presenter.takeView(this);
+        if (!isInEditMode()) {
+            presenter.takeView(this);
+        }
     }
 
     @Override
     protected void onDetachedFromWindow() {
-        presenter.dropView(this);
+        if (!isInEditMode()) {
+            presenter.dropView(this);
+        }
         super.onDetachedFromWindow();
     }
 


### PR DESCRIPTION
Avoid NPE when view is in edit mode

``` java
public class MyView extends PresentedFrameLayout<MyPresenter> {

    public MyView(Context context, AttributeSet attrs) {
        super(context, attrs);
        if (!isInEditMode()) {
            DaggerService.<MyPresenter>getDaggerComponent(context).inject(this);
        }
    }
    ...
}
```

``` xml
<foo.bar.MyView xmlns:android="http://schemas.android.com/apk/res/android"
    android:layout_width="match_parent"
    android:layout_height="match_parent">
   ...
</foo.bar.MyView>
```
