### PR TITLE
Fix crash if onCreate called without onDestroy.

### DIFF
--- a/architect/src/main/java/architect/NavigatorLifecycleDelegate.java
+++ b/architect/src/main/java/architect/NavigatorLifecycleDelegate.java
@@ -41,6 +41,14 @@ public class NavigatorLifecycleDelegate {
             }
         }
 
+        // It is possible for onDestroy to not be called when the activity is destroyed, even when
+        // the rest of the app is not killed by the OS. This check ensures that if this circumstance
+        // has arisen, the method that would have been triggered by onDestroy is triggered here
+        // before the containerView is attached to the presenter and the dispatcher is activated.
+        if (navigator.presenter.hasView()) {
+            this.onDestroy();
+        }
+
         navigator.presenter.attach(containerView);
         navigator.dispatcher.activate();
     }

--- a/architect/src/main/java/architect/Presenter.java
+++ b/architect/src/main/java/architect/Presenter.java
@@ -284,4 +284,8 @@ class Presenter {
 
         void onPresentationFinished(int sessionId);
     }
+
+    boolean hasView() {
+        return this.view != null;
+    }
 }


### PR DESCRIPTION
I have observed in the wild that sometimes an activity is destroyed
without onDestroy() being called, but because the Navigator is in a
Mortar scope linked to the life of the Application object, it is not
destroyed. Thus, when onCreate() is next called, the Preconditions check
that Navigator.presenter.view is null fails. This works around the
problem by checking in NavigatorLifecycleDelegate.onCreate() if there is
already a view in the Navigator.presenter, and if so, running
NavigatorLifecycleDelegate.onDestroy() before attempting to attach the
new view to the Navigator.presenter().

I haven't been able to trigger the exact circumstances in the wild that
are triggering this degenerate case, but I have tested the fix by
deliberately leaving out the call to
NavigatorLifecycleDelegate.onDestroy() in my activity's onDestroy()
method and this fix stops it from crashing in that case, when the
activity is recreated. On this basis, I believe this addresses Bug #26.
